### PR TITLE
Change default text color to red

### DIFF
--- a/frontend/lib/theme.dart
+++ b/frontend/lib/theme.dart
@@ -32,9 +32,9 @@ final ThemeData theme = ThemeData(
   // Text styles
   textTheme: const TextTheme(
     bodyMedium: TextStyle(
-        color: Color.fromARGB(255, 221, 220, 220)), // Default text color
+        color: Colors.red), // Default text color
     bodyLarge: TextStyle(
-        color: Color.fromARGB(255, 221, 220, 220)), // Large body text color
+        color: Colors.red), // Large body text color
   ),
 
   // Radio button style


### PR DESCRIPTION
## Summary
- update TextTheme colors in `frontend/lib/theme.dart` to red

## Testing
- `flutter --version` *(fails: command not found)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685779ae0f50832480d2eff3d8a9f4a5